### PR TITLE
Improve test_current_help_in_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,17 @@ Usage:
   tpl --help
   tpl --version
 
+
+tpl uses the Jinja2 templating engine to render it's output. You can find the
+documentation for template designers at:
+    http://jinja.pocoo.org/docs/latest/templates/
+
+If you provide multiple data sources they will be merged together. If a key is
+present in more than one source the value of the source that was specified
+last will be used.
+
 Options:
   -e, --environment    Use all environment variables as data
   --json=<file>        Load JSON data from a file or STDIN
   --yaml=<file>        Load YAML data from a file or STDIN
-
-Documentation:
-  Jinja2               http://jinja.pocoo.org/docs/latest/
 ```

--- a/tests/cli/test_help_and_usage.py
+++ b/tests/cli/test_help_and_usage.py
@@ -32,22 +32,3 @@ def test_version_on_version(cli):
     p = cli("--version")
     assert p.returncode == 0
     assert "tpl - " in p.stdout
-
-
-def test_current_help_in_readme(cli):
-    p = """Usage:
-  tpl [options] <template_file>
-  tpl --help
-  tpl --version
-
-Options:
-  -e, --environment    Use all environment variables as data
-  --json=<file>        Load JSON data from a file or STDIN
-  --yaml=<file>        Load YAML data from a file or STDIN
-
-Documentation:
-  Jinja2               http://jinja.pocoo.org/docs/latest/
-"""
-
-    with open("./README.md", "r") as readme:
-        assert p in readme.read()

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,0 +1,12 @@
+import unittest.mock
+
+
+import tpl
+
+
+def test_current_help_in_readme(capsys):
+    with unittest.mock.patch("jinja2.__version__", "latest"):
+        tpl.print_help()
+    output = capsys.readouterr()
+    with open("./README.md", "r") as readme:
+        assert output.err in readme.read()

--- a/tpl/__init__.py
+++ b/tpl/__init__.py
@@ -87,14 +87,20 @@ def print_help():
     if "dev" in jinja_version:
         jinja_version = "dev"
     help_text = """
+
+tpl uses the Jinja2 templating engine to render it's output. You can find the
+documentation for template designers at:
+    http://jinja.pocoo.org/docs/{jinja_version}/templates/
+
+If you provide multiple data sources they will be merged together. If a key is
+present in more than one source the value of the source that was specified
+last will be used.
+
 Options:
   -e, --environment    Use all environment variables as data
   --json=<file>        Load JSON data from a file or STDIN
-  --yaml=<file>        Load YAML data from a file or STDIN
-
-Documentation:
-  Jinja2               http://jinja.pocoo.org/docs/{0}/"""
-    print(help_text.format(jinja_version), file=sys.stderr)
+  --yaml=<file>        Load YAML data from a file or STDIN"""
+    print(help_text.format(jinja_version=jinja_version), file=sys.stderr)
 
 
 def print_version():


### PR DESCRIPTION
I changed the way the README test works. There's only one place in the codebase where the help message is defined and we can still change the Jinja version that the README links to.

Also I wrote a little explanation text and moved it in-between the usage and options.

What do you think of this?